### PR TITLE
rename vz500 to laser500

### DIFF
--- a/src/makefiles/targets/makefiles_z88dk/Makefile_z88dk_l-m
+++ b/src/makefiles/targets/makefiles_z88dk/Makefile_z88dk_l-m
@@ -19,9 +19,9 @@ laser500:
 	-DCONIO -DNO_INIT_GRAPHICS \
 	-lndos \
 	$(FULL_FILES)
-	mv a.bin $(BUILD_PATH)/FULL_vz500.bin
+	mv a.bin $(BUILD_PATH)/FULL_laser500.bin
 	rm a.cas
-	mv a.wav $(BUILD_PATH)/FULL_vz500.wav
+	mv a.wav $(BUILD_PATH)/FULL_laser500.wav
 
 
 m100:


### PR DESCRIPTION
as the computer was never known as "vz500". 

The label "VZ" refers to the previous models (Laser 110, 210, 310) branded by Dick Smith and sold in Australia.